### PR TITLE
Expose guest onboot state

### DIFF
--- a/custom_components/proxmox_sensors/api.py
+++ b/custom_components/proxmox_sensors/api.py
@@ -209,8 +209,16 @@ class ProxmoxClient:
     async def get_vms(self, hass, node: str):
         return await self.get(hass, f"nodes/{node}/qemu") or []
 
+    async def get_qemu_config(self, hass, node: str, vmid: str):
+        """Return QEMU VM configuration, including the onboot flag."""
+        return await self.get(hass, f"nodes/{node}/qemu/{vmid}/config") or {}
+
     async def get_containers(self, hass, node: str):
         return await self.get(hass, f"nodes/{node}/lxc") or []
+
+    async def get_lxc_config(self, hass, node: str, vmid: str):
+        """Return LXC configuration, including the onboot flag."""
+        return await self.get(hass, f"nodes/{node}/lxc/{vmid}/config") or {}
 
     async def get_container_status(self, hass, node: str, vmid: str):
         return await self.get(hass, f"nodes/{node}/lxc/{vmid}/status/current")

--- a/custom_components/proxmox_sensors/coordinator.py
+++ b/custom_components/proxmox_sensors/coordinator.py
@@ -460,6 +460,31 @@ async def create_proxmox_coordinator(hass, entry, client):
                         base.setdefault("status", "unknown")
                         vms_dict[guest_key] = base
 
+                    # Fetch VM configuration so HA can compare actual state with
+                    # Proxmox's own Start-at-boot setting.
+                    if vms_dict:
+                        vm_keys = list(vms_dict.keys())
+                        vm_configs = await asyncio.gather(
+                            *(
+                                limited_task(
+                                    client.get_qemu_config,
+                                    hass,
+                                    node,
+                                    str(vms_dict[key].get("vmid")),
+                                )
+                                for key in vm_keys
+                            ),
+                            return_exceptions=True,
+                        )
+                        for key, vm_config in zip(vm_keys, vm_configs):
+                            if isinstance(vm_config, dict):
+                                try:
+                                    vms_dict[key]["onboot"] = (
+                                        int(vm_config.get("onboot", 0)) == 1
+                                    )
+                                except (TypeError, ValueError):
+                                    vms_dict[key]["onboot"] = False
+
                     result["vms"] = vms_dict
 
                     # -------- Containers --------
@@ -493,6 +518,30 @@ async def create_proxmox_coordinator(hass, entry, client):
                             base.setdefault(field, 0)
                         base.setdefault("status", "unknown")
                         cts_dict[guest_key] = base
+
+                    # Fetch LXC configuration for the Start-at-boot flag.
+                    if cts_dict:
+                        ct_keys = list(cts_dict.keys())
+                        ct_configs = await asyncio.gather(
+                            *(
+                                limited_task(
+                                    client.get_lxc_config,
+                                    hass,
+                                    node,
+                                    str(cts_dict[key].get("vmid")),
+                                )
+                                for key in ct_keys
+                            ),
+                            return_exceptions=True,
+                        )
+                        for key, ct_config in zip(ct_keys, ct_configs):
+                            if isinstance(ct_config, dict):
+                                try:
+                                    cts_dict[key]["onboot"] = (
+                                        int(ct_config.get("onboot", 0)) == 1
+                                    )
+                                except (TypeError, ValueError):
+                                    cts_dict[key]["onboot"] = False
 
                     result["cts"] = cts_dict
 

--- a/custom_components/proxmox_sensors/sensor/ct.py
+++ b/custom_components/proxmox_sensors/sensor/ct.py
@@ -67,6 +67,14 @@ class ProxmoxContainerSensor(ProxmoxBaseSensor):
         if node := ct_data.get("node"):
             attrs["node"] = node
 
+        if "onboot" in ct_data:
+            onboot = bool(ct_data.get("onboot"))
+            expected_state = "Running" if onboot else "Stopped"
+            actual_state = str(ct_data.get("status", "unknown")).capitalize()
+            attrs["onboot"] = onboot
+            attrs["expected_state"] = expected_state
+            attrs["state_matches_onboot"] = actual_state == expected_state
+
         return attrs
 
 class ProxmoxContainerAttributeSensor(ProxmoxBaseSensor):

--- a/custom_components/proxmox_sensors/sensor/vm.py
+++ b/custom_components/proxmox_sensors/sensor/vm.py
@@ -56,6 +56,14 @@ class ProxmoxVMSensor(ProxmoxBaseSensor):
         if node := vm_data.get("node"):
             attrs["node"] = node
 
+        if "onboot" in vm_data:
+            onboot = bool(vm_data.get("onboot"))
+            expected_state = "Running" if onboot else "Stopped"
+            actual_state = str(vm_data.get("status", "unknown")).capitalize()
+            attrs["onboot"] = onboot
+            attrs["expected_state"] = expected_state
+            attrs["state_matches_onboot"] = actual_state == expected_state
+
         return attrs
     
 class ProxmoxVMAttributeSensor(ProxmoxBaseSensor):


### PR DESCRIPTION
## Summary

Expose Proxmox’s `onboot` (“Start at boot”) setting for QEMU virtual machines and LXC containers through their Home Assistant status sensors.

The status sensors now provide these additional attributes:

* `onboot`: configured Proxmox start-at-boot setting
* `expected_state`: `Running` when `onboot` is enabled, otherwise `Stopped`
* `state_matches_onboot`: whether the current guest state matches the configured expectation

## Motivation

This makes it possible to highlight virtual machines and containers that are unexpectedly running or stopped directly on a Home Assistant dashboard. Proxmox’s own configuration remains the source of truth.

## Implementation

* Added API helpers for the QEMU and LXC configuration endpoints.
* Guest configurations are fetched concurrently using the coordinator’s existing request limiter.
* Added the derived attributes to VM and container status sensors.
* Failed or unavailable configuration responses do not interrupt coordinator updates.

## Validation

* Tested with Home Assistant Core 2026.8.2 against a live Proxmox VE installation.
* Python syntax validated for all four modified files.
* The PR contains one commit and modifies only the four relevant integration files.
